### PR TITLE
fix multiple clicks

### DIFF
--- a/js/ui/panel.mjs
+++ b/js/ui/panel.mjs
@@ -50,13 +50,19 @@ function activatePanelButtonOnCoordinates(x, y) {
 }
 
 function attachMouseListeners() {
-  window.addEventListener("click", (event) => {
+  function handleMouseClick(event) {
     activatePanelButtonOnCoordinates(event.clientX, event.clientY);
-  });
+  }
+
+  window.addEventListener("click", handleMouseClick);
+
+  return function dispose() {
+    window.removeEventListener("click", handleMouseClick);
+  };
 }
 
 function attachKeyboardListeners(state) {
-  window.addEventListener("keydown", (event) => {
+  function handleKeyDown(event) {
     if (event.key !== "Enter") {
       return;
     }
@@ -64,7 +70,13 @@ function attachKeyboardListeners(state) {
     const cursor = state.get((prevState) => prevState.cursor);
 
     activatePanelButtonOnCoordinates(cursor.x, cursor.y);
-  });
+  }
+
+  window.addEventListener("keydown", handleKeyDown);
+
+  return function dispose() {
+    window.removeEventListener("keydown", handleKeyDown);
+  };
 }
 
 function attachGamepadListeners(state) {


### PR DESCRIPTION
Fixes #1 

Whenever button was activated (either via mouse or keyboard or gamepad), the related handler would be triggered multiple times.

This was caused by the logic in panel module and the reason behind this was that the handlers were attached repeatedly whenever fill tool was used.

Fill tools deactivates & activates UI. During activation, the panel would re-attach handlers **but** without discarding the old handlers.

This resulted in multiple handlers being fired, e.g. prompt for clearing canvas shown multiple times.